### PR TITLE
chore(ci): build and publish docker image

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 
-DOCKER_IMAGE_NAME="theborakompanioni/vanitytorgen"
+DOCKER_IMAGE_NAME="Kexkey/vanitytorgen"
 DOCKER_IMAGE_VERSION="latest"

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+
+DOCKER_IMAGE_NAME="theborakompanioni/vanitytorgen"
+DOCKER_IMAGE_VERSION="latest"

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -1,0 +1,74 @@
+name: Build and publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  readenv:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docker_image_name: ${{ steps.dotenv.outputs.docker_image_name }}
+      docker_image_version: ${{ steps.dotenv.outputs.docker_image_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read .env file
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs: readenv
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3.10.0
+        with:
+          install: true
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ needs.readenv.outputs.docker_image_name }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.readenv.outputs.docker_image_version }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6.15.0
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,51 @@
+
+name: Build Docker image
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - devel
+
+env:
+  TEST_TAG: test
+
+jobs:
+  readenv:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docker_image_name: ${{ steps.dotenv.outputs.docker_image_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read .env file
+        id: dotenv
+        uses: falti/dotenv-action@v1.1.4
+        with:
+          log-variables: true
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: readenv
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          load: true
+          push: false
+          tags: ${{ needs.readenv.outputs.docker_image_name }}:${{ env.TEST_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386
 
 WORKDIR /go/src/vanitytorgen
 


### PR DESCRIPTION
Enables docker build in GitHub Actions (on push and PRs) and published to GitHub docker registry (when tagged with `v*`).